### PR TITLE
Fixes #50 - Plot discrete points from terminal

### DIFF
--- a/gui_main.py
+++ b/gui_main.py
@@ -91,8 +91,8 @@ class New_Toplevel_1:
         self.fx.configure(font="TkFixedFont")
         self.fx.configure(width=296)
         self.fx.bind('<Return>', lambda x: gui_support.Plot(self.fx.get(),
-                                                            self.x_lower.get(),
-                                                            self.x_upper.get(),
+                                                            range(int(self.x_lower.get()),
+                                                                  int(self.x_upper.get())),
                                                             self.color_input.get(),
                                                             self.theme,
                                                             self.Canvas1))
@@ -137,8 +137,8 @@ class New_Toplevel_1:
         self.bt_plot.place(relx=0.67, rely=0.85, height=26, width=47)
         self.bt_plot.configure(activebackground=_activebgcolordark)
         self.bt_plot.configure(command=lambda: gui_support.Plot(self.fx.get(),
-                                                                self.x_lower.get(),
-                                                                self.x_upper.get(),
+                                                                range(int(self.x_lower.get()),
+                                                                      int(self.x_upper.get())),
                                                                 self.color_input.get(),
                                                                 self.theme,
                                                                 self.Canvas1))
@@ -180,8 +180,8 @@ class New_Toplevel_1:
         self.bt_go.place(relx=0.90, rely=0.47, height=20, width=40)
         self.bt_go.configure(activebackground=_activebgcolordark)
         self.bt_go.configure(command=lambda: gui_support.Plot(self.fx.get(),
-                                                              self.x_lower.get(),
-                                                              self.x_upper.get(),
+                                                              range(int(self.x_lower.get()),
+                                                                    int(self.x_upper.get())),
                                                               self.color_input.get(),
                                                               self.theme,
                                                               self.Canvas1))
@@ -295,8 +295,9 @@ class New_Toplevel_1:
 
     def resize_plot(self, event):
         if gui_support.plotted:
-            gui_support.Plot(self.fx.get(), self.x_lower.get(), self.x_upper.get(),
-                             self.color_input.get(), self.theme, self.Canvas1)
+            gui_support.Plot(self.fx.get(), range(int(self.x_lower.get()),
+                             int(self.x_upper.get())), self.color_input.get(),
+                             self.theme, self.Canvas1)
 
     @staticmethod
     def popup1(event):

--- a/gui_support.py
+++ b/gui_support.py
@@ -26,12 +26,11 @@ from lib import plotutil as plu
 plotted = False
 
 
-def Plot(fx, x_l, x_u, color_name, theme, canvas):
+def Plot(fx, xpoints, color_name, theme, canvas):
 
     global plotted
     if fx:
-        plu.plot(fx, int(x_l), int(x_u), 1.0,
-                 color_name, 'X-axis', 'Y-axis', theme, True)
+        plu.plot(fx, xpoints, color_name, 'X-axis', 'Y-axis', theme, True)
         image = Image.open(".temp/generated_plot.png").resize(
             (canvas.winfo_width(), canvas.winfo_height()))
         gif1 = ImageTk.PhotoImage(image, Image.ANTIALIAS)

--- a/lib/plotutil.py
+++ b/lib/plotutil.py
@@ -20,28 +20,31 @@ def create_y_values(func, xvals):
     return yvals
 
 
-def plot(func, xstart, xend, step, color_name, xlabel, ylabel, theme, gui):
+def plot(func, xpoints, color_name, xlabel, ylabel, theme, gui, discrete=False):
 
     # Show plot summary
     print('***** Plot Summary *****')
-    print('Funtion: {}'.format(func))
-    print('Starting abcissa: {}'.format(xstart))
-    print('Ending abcissa: {}'.format(xend))
-    print('Step size: {}'.format(step))
-    print('Color: {}'.format(color_name))
-    print('X-label: {}'.format(xlabel))
-    print('Y-label: {}'.format(ylabel))
+    print("Funtion: {}".format(func))
+
+    if discrete:
+        print("Plotting funcion for points: {}".format(', '.join(map(str, xpoints))))
+    else:
+        print("Starting abcissa: {}".format(xpoints[0]))
+        print("Ending abcissa: {}".format(xpoints[-1]))
+        if (len(xpoints) > 1):
+            print("Stepsize: {}".format(xpoints[1] - xpoints[0]))
+
+    print("Color: {}".format(color_name))
+    print("X-label: {}".format(xlabel))
+    print("Y-label: {}".format(ylabel))
+    print()
 
     if theme == 'dark':
         mplstyle.use('dark_background')
     else:
         mplstyle.use('default')
 
-    xvals = []
-    i = xstart
-    while i <= xend:
-        xvals.append(i)
-        i += step
+    xvals = xpoints
     yvals = create_y_values(func, xvals)
 
     try:

--- a/plotit.py
+++ b/plotit.py
@@ -36,6 +36,9 @@ parser.add_option('-x', '--xlabel', dest='xlabel',
                   help='Enter the x-label for plot')
 parser.add_option('-y', '--ylabel', dest='ylabel',
                   help='Enter the y-label for plot')
+parser.add_option('-p', '--points', dest='xpoints',
+                  help='Enter discrete x values for which the \
+                  function will be plotted like [x1,x2,x3,...,xn]')
 parser.add_option('-l', '--line', dest='line',
                   help='Enter 2 Arrays of X and Y Coordinates like \
                   [x1,x2,x3,...,xn],[y1,y2,y3,...,yn]')
@@ -66,18 +69,34 @@ else:
 if options.func:
     func = options.func
 
-    if options.xstart:
-        xstart = int(options.xstart)
+    if options.xpoints and (options.xstart or options.xend or options.stepsize):
+        parser.error("Can't use either of xstart, xend or stepsize \
+                     with the option xpoints")
+    elif options.xpoints:
+        xpoints = list(map(float, options.xpoints[1:-1].split(',')))
+        discrete = True
+    else:
+        if options.xstart:
+            xstart = int(options.xstart)
+        else:
+            xstart = 0
 
-    if options.xend:
-        xend = int(options.xend)
+        if options.xend:
+            xend = int(options.xend)
+        else:
+            xend = 100
 
-    if options.stepsize:
-        stepsize = int(options.stepsize)
+        if options.stepsize:
+            stepsize = int(options.stepsize)
+        else:
+            stepsize = 1
 
-    plu.plot(func, xstart, xend, stepsize, color, xlabel, ylabel, theme, False)
+        xpoints = range(xstart, xend + 1, stepsize)
+        discrete = False
 
-else:  # no function try to take points for line
+    plu.plot(func, xpoints, color, xlabel, ylabel, theme, False, discrete)
+
+else:  # No function, hence try to take points for line
     xypoints = options.line
     plu.plot_line(xypoints, color, xlabel, ylabel, theme, False)
 


### PR DESCRIPTION
An additional flag -p has been introduced to give discrete x points and also the xpoints option is mutually exclusive with xstart, xend and stepsize as one can't have both. The function plot of lib/plotutil.py now receives only the range of x values and an additional argument discrete which specifies whether points are discrete.